### PR TITLE
Add ability to parse the media line IDs from the SDP

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,32 @@ module.exports = function(sdp) {
   };
 
   /**
+    ### `sdp.getMediaIDs() => []`
+
+    Returns the list of unique media line IDs that have been defined in the sdp
+    via `a=mid:` lines.
+   **/
+  ops.getMediaIDs = function() {
+    return parsed.filter(function(parts) {
+      return parts[0] === 'm' && parts[1] && parts[1].childlines && parts[1].childlines.length > 0;
+    }).map(function(mediaLine) {
+      var lines = mediaLine[1].childlines;
+      // Default ID to the media type
+      var mediaId = mediaLine[1].def.split(/\s/)[0];
+
+      // Look for the media ID
+      for (var i = 0; i < lines.length; i++) {
+        var tokens = lines[i][1].split(':');
+        if (tokens.length > 0 && tokens[0] === 'mid') {
+          mediaId = tokens[1];
+          break;
+        }
+      }
+      return mediaId;
+    });
+  };
+
+  /**
     ### `sdp.toString()`
 
     Convert the SDP structure that is currently retained in memory, into a string

--- a/test/all.js
+++ b/test/all.js
@@ -2,3 +2,4 @@ require('./parse');
 require('./candidates-add-video');
 require('./constrain-bandwidth');
 require('./count-lines');
+require('./media-types');

--- a/test/fragments/test-media-types-firefox.txt
+++ b/test/fragments/test-media-types-firefox.txt
@@ -1,0 +1,53 @@
+v=0
+o=mozilla...THIS_IS_SDPARTA-43.0 7615916235551427372 0 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=fingerprint:sha-256 83:6D:DB:4F:47:3C:E2:46:BB:96:2E:D6:A9:1C:F2:F5:A7:EF:66:93:90:5D:FB:F6:E5:58:ED:00:85:6C:C6:2C
+a=group:BUNDLE sdparta_0 sdparta_1 sdparta_2
+a=ice-options:trickle
+a=msid-semantic:WMS *
+m=audio 9 UDP/TLS/RTP/SAVPF 109 9 0 8c=IN IP4 0.0.0.0
+a=recvonly
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=ice-pwd:66cffb29579a0f50c224bdde1a57bd37
+a=ice-ufrag:b083188e
+a=mid:sdparta_0
+a=rtcp-mux
+a=rtpmap:109 opus/48000/2
+a=rtpmap:9 G722/8000/1
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=setup:actpass
+a=ssrc:2950329833 cname:{e911ffa4-e987-fb42-a124-94d281ca8b86}
+m=video 9 UDP/TLS/RTP/SAVPF 120 126 97
+c=IN IP4 0.0.0.0
+a=recvonly
+a=fmtp:120 max-fs=12288;max-fr=60
+a=fmtp:126 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1
+a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1
+a=ice-pwd:66cffb29579a0f50c224bdde1a57bd37
+a=ice-ufrag:b083188e
+a=mid:sdparta_1
+a=rtcp-fb:120 nack
+a=rtcp-fb:120 nack pli
+a=rtcp-fb:120 ccm fir
+a=rtcp-fb:126 nack
+a=rtcp-fb:126 nack pli
+a=rtcp-fb:126 ccm fir
+a=rtcp-fb:97 nack
+a=rtcp-fb:97 nack pli
+a=rtcp-fb:97 ccm fir
+a=rtcp-mux
+a=rtpmap:120 VP8/90000
+a=rtpmap:126 H264/90000
+a=rtpmap:97 H264/90000
+a=setup:actpass
+a=ssrc:2518289365 cname:{e911ffa4-e987-fb42-a124-94d281ca8b86}
+m=application 9 DTLS/SCTP 5000c=IN IP4 0.0.0.0
+a=sendrecv
+a=ice-pwd:66cffb29579a0f50c224bdde1a57bd37
+a=ice-ufrag:b083188e
+a=mid:sdparta_2
+a=sctpmap:5000 webrtc-datachannel 256
+a=setup:actpass
+a=ssrc:3546236976 cname:{e911ffa4-e987-fb42-a124-94d281ca8b86}

--- a/test/media-types.js
+++ b/test/media-types.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var test = require('tape');
-var baseSdp = fs.readFileSync(__dirname + '/fragments/test-answer-nodata.txt', 'utf8');
+var baseSdp = fs.readFileSync(__dirname + '/fragments/test-media-types-firefox.txt', 'utf8');
 var parse = require('..');
 var sdp;
 
@@ -11,11 +11,10 @@ test('can parse the target sdp', function(t) {
 
 test('can determine that we have an audio and video line only in the sdp', function(t) {
   t.plan(1);
-  t.deepEqual(sdp.getMediaTypes(), ['audio', 'video'], 'ok');
+  t.deepEqual(sdp.getMediaTypes(), ['audio', 'video', 'application'], 'ok');
 });
-
 
 test('can determine the media ids that exist in the sdp', function(t) {
   t.plan(1);
-  t.deepEqual(sdp.getMediaIDs(), ['audio', 'video'], 'ok');
+  t.deepEqual(sdp.getMediaIDs(), ['sdparta_0', 'sdparta_1', 'sdparta_2'], 'ok');
 });


### PR DESCRIPTION
As above, return the media IDs based on the`a=mid:` value, as while types and IDs have been relatively interchangeable up until now, changes present in Firefox Beta will require the use of the IDs (in `rtc-taskqueue`)
