### PR TITLE
Update prefer-codecs.js

### DIFF
--- a/prefer-codecs.js
+++ b/prefer-codecs.js
@@ -42,10 +42,12 @@ module.exports = function(desiredCodecs, mediaType) {
     // Build the codec definition
     var codec = result[2];
     var typeNum = result[1];
-    r[codec.toUpperCase()] = {
-      num: typeNum,
-      codec: codec
-    }
+    // Use the first appearance of the specific codec, not the last
+    if (!r[codec.toUpperCase()])
+      r[codec.toUpperCase()] = {
+        num: typeNum,
+        codec: codec
+      }
     return r;
   }
 

--- a/prefer-codecs.js
+++ b/prefer-codecs.js
@@ -1,7 +1,7 @@
 var parser = require('./index');
 var tools = require('./tools');
 var ianaCodecs = require('./iana-codecs');
-var reRtpMap = /^rtpmap:([0-9]*)\s*([^\s]*)/ig;
+var reRtpMap = /^rtpmap:([0-9]*)\s*([^\s]*)/i;
 
 /**
 


### PR DESCRIPTION
Took me a while to figure out that the /g flag is deadly in case there is more than one codec definition in the SDP. The second is simply not detected by the regexp, even though the regexp is completely fine - except the /g